### PR TITLE
feat(proto): add `visible_container_type_names` and `container_group` fields, refine container type enum

### DIFF
--- a/container.proto
+++ b/container.proto
@@ -1,6 +1,7 @@
 syntax = "proto2";
 package raccoonai;
 
+import "container_type.proto";
 import "google/protobuf/timestamp.proto";
 
 option go_package = "./pb";
@@ -11,39 +12,26 @@ enum ContainerStatus {
   CONTAINER_STATUS_ACTIVE = 2;
 }
 
-message ContainerType {
-  required uint64 id = 1 [json_name = "id"];
-  required google.protobuf.Timestamp created_at = 2 [json_name = "created_at"];
-  required string type_name = 3 [json_name = "type_name"];
-  required uint64 owner_organization_id = 5 [json_name = "owner_organization_id"];
-  required float cubic_meter = 6 [json_name = "cubic_meter"];
-  required uint64 weight = 7 [json_name = "weight"];
-}
-
-message ContainerTypeCreate {
-  required string type_name = 1 [json_name = "type_name"];
-  required uint64 owner_organization_id = 2 [json_name = "owner_organization_id"];
-  required float cubic_meter = 3 [json_name = "cubic_meter"];
-  required uint64 weight = 4 [json_name = "weight"];
-}
-
-message ContainerTypeUpdate {
-  required uint64 id = 1 [json_name = "id"];
-  optional string type_name = 2 [json_name = "type_name"];
-  optional float cubic_meter = 3 [json_name = "cubic_meter"];
-  optional uint64 weight = 4 [json_name = "weight"];
-}
+//enum ContainerTypeName {
+//  CONTAINER_TYPE_NAME_UNDEFINED = 0;
+//  CONTAINER_TYPE_NAME_EURO = 1;
+//  CONTAINER_TYPE_NAME_C8 = 2;
+//  CONTAINER_TYPE_NAME_C10 = 3;
+//  CONTAINER_TYPE_NAME_C14 = 4;
+//  CONTAINER_TYPE_NAME_C23 = 5;
+//}
 
 message Container {
   required uint64 id = 1 [json_name = "id"];
   required google.protobuf.Timestamp created_at = 2 [json_name = "created_at"];
   required string name = 3 [json_name = "name"];
-  required ContainerType type = 4 [json_name = "type"];
+  required ContainerTypeRead type = 4 [json_name = "type"];
   required ContainerStatus status = 5 [json_name = "status"];
   required uint64 owner_organization_id = 6 [json_name = "owner_organization_id"];
   required bool is_tracked = 7 [json_name = "is_tracked"];
   optional uint64 location_id = 8 [json_name = "location_id"];
   required google.protobuf.Timestamp updated_at = 9 [json_name = "updated_at"];
+  required uint64 type_id = 10 [json_name = "type_id"];
 }
 
 message ContainerCreate {

--- a/container_in_location.proto
+++ b/container_in_location.proto
@@ -1,0 +1,36 @@
+syntax = "proto2";
+package raccoonai;
+
+import "container_type.proto";
+import "google/protobuf/timestamp.proto";
+import "location.proto";
+
+option go_package = "./pb";
+
+message ContainerInLocation {
+  required uint64 id = 1 [json_name = "id"];
+  required google.protobuf.Timestamp created_at = 2 [json_name = "created_at"];
+  required uint64 owner_organization_id = 3 [json_name = "owner_organization_id"];
+
+  required uint64 location_id = 4 [json_name = "location_id"];
+  required LocationRead location = 5 [json_name = "location"];
+
+  required uint64 container_type_id = 6 [json_name = "container_type_id"];
+  required ContainerTypeRead container_type = 7 [json_name = "container_type"];
+
+  required uint64 quantity = 8 [json_name = "quantity"];
+}
+
+message ContainerInLocationCreate {
+  required uint64 owner_organization_id = 1 [json_name = "owner_organization_id"];
+  required uint64 location_id = 2 [json_name = "location_id"];
+  required uint64 container_type_id = 3 [json_name = "container_type_id"];
+  required uint64 quantity = 4 [json_name = "quantity"];
+}
+
+message ContainerInLocationUpdate {
+  required uint64 id = 1 [json_name = "id"];
+  optional uint64 location_id = 2 [json_name = "location_id"];
+  optional uint64 container_type_id = 3 [json_name = "container_type_id"];
+  optional uint64 quantity = 4 [json_name = "quantity"];
+}

--- a/container_type.proto
+++ b/container_type.proto
@@ -1,0 +1,35 @@
+syntax = "proto2";
+package raccoonai;
+
+import "google/protobuf/timestamp.proto";
+
+option go_package = "./pb";
+
+message ContainerType {
+  required uint64 id = 1 [json_name = "id"];
+  required google.protobuf.Timestamp created_at = 2 [json_name = "created_at"];
+  required google.protobuf.Timestamp updated_at = 3 [json_name = "updated_at"];
+  required uint64 owner_organization_id = 4 [json_name = "owner_organization_id"];
+  required string name = 5 [json_name = "name"];
+  required float volume = 6 [json_name = "volume"];
+  optional uint64 weight = 7 [json_name = "weight"];
+}
+
+message ContainerTypeRead {
+  required uint64 id = 1 [json_name = "id"];
+  required string name = 2 [json_name = "name"];
+}
+
+message ContainerTypeCreate {
+  required string name = 1 [json_name = "name"];
+  optional uint64 owner_organization_id = 2 [json_name = "owner_organization_id"];
+  required float volume = 3 [json_name = "volume"];
+  optional uint64 weight = 4 [json_name = "weight"];
+}
+
+message ContainerTypeUpdate {
+  required uint64 id = 1 [json_name = "id"];
+  optional string name = 2 [json_name = "name"];
+  optional float volume = 3 [json_name = "volume"];
+  optional uint64 weight = 4 [json_name = "weight"];
+}

--- a/job.proto
+++ b/job.proto
@@ -13,13 +13,29 @@ option go_package = "./pb";
 
 enum JobType {
   JOB_TYPE_UNDEFINED = 0;
-  // JOB CATEGORY CO
-  JOB_TYPE_SERVICE = 1;
-  JOB_TYPE_ADD_BUNKER = 2;
-  JOB_TYPE_REMOVE_BUNKER = 3;
-  // JOB CATEGORY MSW
-  JOB_TYPE_MSW = 100; // Municipal Solid Waste
-  // OTHER JOB CATEGORIES
+
+  //  Core Bunker Operations
+  JOB_TYPE_REPLACE_BUNKER = 1; // Забрать с заменой
+  JOB_TYPE_ADD_BUNKER = 2; // Установить ёмкость
+  JOB_TYPE_REMOVE_BUNKER = 3; // Забрать без замены
+
+  //  Sanitation & Maintenance
+  JOB_TYPE_CLEANUP = 4; // Подбор (Standard site cleanup)
+  JOB_TYPE_MOBILE_CLEANUP = 5; // Подбор с объездом
+  JOB_TYPE_APPLY_BRANDING = 6; // Брендировать ёмкость
+  JOB_TYPE_DISINFECTION = 7; // Дезинфекция
+
+  //  Logistics
+  JOB_TYPE_TRANSPORTATION = 8; // Перевозка
+  JOB_TYPE_TRANSPORTATION_MPS = 9; // Перевозка (МПС - МПС)
+
+  // Miscellaneous
+  JOB_TYPE_BRAND_CONTAINER = 10; // Брендировать ёмкость
+  JOB_TYPE_REPAIR_CONTAINER = 11; // Ремонт ёмкости
+  JOB_TYPE_DECOMMISSION_CONTAINER = 12; // Снять ёмкость
+  JOB_TYPE_INSTALL_LID = 13; // Установить крышку
+  JOB_TYPE_REMOVE_LID = 14; // Снять крышку
+  JOB_TYPE_INSTALL_TAG = 15; // Установить идентификатор
 }
 
 enum JobCategory {

--- a/location.proto
+++ b/location.proto
@@ -17,6 +17,9 @@ enum LocationType {
   LOCATION_TYPE_DEPOT = 1;
   LOCATION_TYPE_DISPOSAL_SITE = 2;
   LOCATION_TYPE_GAS_STATION = 3;
+  LOCATION_TYPE_CONSTRUCTION = 4;
+  LOCATION_TYPE_MSW = 5;
+  LOCATION_TYPE_PICKUP = 6;
 }
 
 message Location {
@@ -33,6 +36,13 @@ message Location {
   required string polymorphic_type = 11 [json_name = "polymorphic_type"];
   optional string gis_link = 12 [json_name = "gis_link"];
   optional uint64 service_time = 13 [json_name = "service_time"];
+}
+
+message LocationRead {
+  required uint64 id = 1 [json_name = "id"];
+  required string name = 3 [json_name = "name"];
+  optional string address = 10 [json_name = "address"];
+  required LocationStatus status = 6 [json_name = "status"];
 }
 
 message LocationCreate {

--- a/organization_service.proto
+++ b/organization_service.proto
@@ -4,7 +4,6 @@ package raccoonai;
 
 import "general.proto";
 import "organization.proto";
-import "truck.proto";
 
 option go_package = "./pb";
 
@@ -25,7 +24,7 @@ message AddGuestRequest {
   required string driver_phone_number = 5 [json_name = "driver_phone_number"];
   optional string driver_license_number = 6 [json_name = "driver_license_number"];
   required string truck_plate_number = 7 [json_name = "truck_plate_number"];
-  required TruckType truck_type = 8 [json_name = "truck_type"];
+  required uint64 truck_type_id = 8 [json_name = "truck_type"];
 }
 
 message AddGuestResponse {

--- a/pickup_location.proto
+++ b/pickup_location.proto
@@ -7,12 +7,6 @@ import "location.proto";
 
 option go_package = "./pb";
 
-enum PickupLocationType {
-  PICKUP_LOCATION_TYPE_UNDEFINED = 0;
-  PICKUP_LOCATION_TYPE_CONSTRUCTION = 1;
-  PICKUP_LOCATION_TYPE_HOUSEHOLD = 2;
-}
-
 enum PickupLocationPriority {
   PICKUP_LOCATION_PRIORITY_UNDEFINED = 0;
   PICKUP_LOCATION_PRIORITY_LOW = 1;
@@ -24,7 +18,7 @@ message PickupLocation {
   required uint64 id = 1 [json_name = "id"];
   required google.protobuf.Timestamp created_at = 2 [json_name = "created_at"];
   required string name = 3 [json_name = "name"];
-  required PickupLocationType type = 4 [json_name = "type"];
+  required LocationType type = 4 [json_name = "type"];
   required uint64 owner_organization_id = 5 [json_name = "owner_organization_id"];
   required LocationStatus status = 6 [json_name = "status"];
   required double lon = 7 [json_name = "lon"];
@@ -48,7 +42,7 @@ message PickupLocation {
 
 message PickupLocationCreate {
   required string name = 1 [json_name = "name"];
-  optional PickupLocationType type = 2 [json_name = "type"];
+  optional LocationType type = 2 [json_name = "type"];
   optional uint64 owner_organization_id = 3 [json_name = "owner_organization_id"];
   required double lon = 4 [json_name = "lon"];
   required double lat = 5 [json_name = "lat"];
@@ -70,7 +64,7 @@ message PickupLocationCreate {
 message PickupLocationUpdate {
   required uint64 id = 1 [json_name = "id"];
   optional string name = 2 [json_name = "name"];
-  optional PickupLocationType type = 3 [json_name = "type"];
+  optional LocationType type = 3 [json_name = "type"];
   optional LocationStatus status = 4 [json_name = "status"];
   optional double lon = 5 [json_name = "lon"];
   optional double lat = 6 [json_name = "lat"];

--- a/service_capability.proto
+++ b/service_capability.proto
@@ -1,0 +1,36 @@
+syntax = "proto2";
+package raccoonai;
+
+import "container_type.proto";
+import "google/protobuf/timestamp.proto";
+import "truck_type.proto";
+
+option go_package = "./pb";
+
+message ServiceCapability {
+  required uint64 id = 1 [json_name = "id"];
+  required google.protobuf.Timestamp created_at = 2 [json_name = "created_at"];
+  required uint64 owner_organization_id = 3 [json_name = "owner_organization_id"];
+
+  required uint64 truck_type_id = 4 [json_name = "truck_type_id"];
+  required TruckTypeRead truck_type = 5 [json_name = "truck_type"];
+
+  required uint64 container_type_id = 6 [json_name = "container_type_id"];
+  required ContainerTypeRead container_type = 7 [json_name = "container_type"];
+
+  required string job_type = 8 [json_name = "job_type"];
+}
+
+message ServiceCapabilityCreate {
+  required uint64 owner_organization_id = 1 [json_name = "owner_organization_id"];
+  required uint64 truck_type_id = 2 [json_name = "truck_type_id"];
+  required uint64 container_type_id = 3 [json_name = "container_type_id"];
+  required string job_type = 4 [json_name = "job_type"];
+}
+
+message ServiceCapabilityUpdate {
+  required uint64 id = 1 [json_name = "id"];
+  optional uint64 truck_type_id = 2 [json_name = "truck_type_id"];
+  optional uint64 container_type_id = 3 [json_name = "container_type_id"];
+  optional string job_type = 4 [json_name = "job_type"];
+}

--- a/truck.proto
+++ b/truck.proto
@@ -2,6 +2,7 @@ syntax = "proto2";
 package raccoonai;
 
 import "google/protobuf/timestamp.proto";
+import "truck_type.proto";
 
 option go_package = "./pb";
 
@@ -13,37 +14,40 @@ enum TruckStatus {
   TRUCK_STATUS_GUEST = 4;
 }
 
-enum TruckType {
-  TRUCK_TYPE_UNDEFINED = 0;
-  TRUCK_TYPE_CONSTRUCTION = 1;
-  TRUCK_TYPE_DOUBLE_CONTAINER = 2; // multilift
-  TRUCK_TYPE_MSW = 3;
-  TRUCK_TYPE_TIPPER = 4; // samosval
-  TRUCK_TYPE_LIQUID_WASTE = 5;
-}
+//enum TruckTypeName {
+//  TRUCK_TYPE_UNDEFINED = 0;
+//  TRUCK_TYPE_CONSTRUCTION = 1;
+//  //  TRUCK_TYPE_DOUBLE_CONTAINER = 2; // manipulator
+//  TRUCK_TYPE_MSW = 3;
+//  TRUCK_TYPE_TIPPER = 4; // samosval
+//  TRUCK_TYPE_LIQUID_WASTE = 5;
+//  TRUCK_TYPE_MULTI_LIFT = 6; // multi-lift
+//  TRUCK_TYPE_ROCKET = 7;
+//}
 
 // GET => /v1/platform/truck/{id}
 message Truck {
   required uint64 id = 1 [json_name = "id"];
   required google.protobuf.Timestamp created_at = 2 [json_name = "created_at"];
-  required TruckType type = 3 [json_name = "type"];
+  required TruckTypeRead type = 3 [json_name = "type"];
   required string plate_number = 4 [json_name = "plate_number"];
   required TruckStatus status = 5 [json_name = "status"];
   required uint64 owner_organization_id = 6 [json_name = "owner_organization_id"];
   optional string model = 7 [json_name = "model"];
-  optional double truck_weight = 8 [json_name = "truck_weight"];
+  optional double weight = 8 [json_name = "weight"];
   optional google.protobuf.Timestamp last_weight_ts = 9 [json_name = "last_weight_ts"];
   optional uint64 capacity = 10 [json_name = "capacity"];
   optional uint64 year = 11 [json_name = "year"];
   optional string color = 12 [json_name = "color"];
+  optional uint64 type_id = 13 [json_name = "type_id"];
 }
 
 message TruckCreate {
-  optional TruckType type = 1 [json_name = "type"];
+  optional uint64 type_id = 1 [json_name = "type_id"];
   required string plate_number = 2 [json_name = "plate_number"];
   optional uint64 owner_organization_id = 3 [json_name = "owner_organization_id"];
   optional string model = 4 [json_name = "model"];
-  optional double truck_weight = 5 [json_name = "truck_weight"];
+  optional double weight = 5 [json_name = "weight"];
   optional uint64 capacity = 6 [json_name = "capacity"];
   optional uint64 year = 7 [json_name = "year"];
   optional string color = 8 [json_name = "color"];
@@ -51,11 +55,11 @@ message TruckCreate {
 
 message TruckUpdate {
   required uint64 id = 1 [json_name = "id"];
-  optional TruckType type = 2 [json_name = "type"];
+  optional uint64 type_id = 2 [json_name = "type_id"];
   optional string plate_number = 3 [json_name = "plate_number"];
   optional TruckStatus status = 4 [json_name = "status"];
   optional string model = 5 [json_name = "model"];
-  optional double truck_weight = 6 [json_name = "truck_weight"];
+  optional double weight = 6 [json_name = "weight"];
   optional uint64 capacity = 7 [json_name = "capacity"];
   optional uint64 year = 8 [json_name = "year"];
   optional string color = 9 [json_name = "color"];

--- a/truck_service.proto
+++ b/truck_service.proto
@@ -23,7 +23,7 @@ message SearchTruckResponse {
 
 message TruckListRequest {
   optional uint64 owner_organization_id = 1 [json_name = "owner_organization_id"]; // filter by org
-  optional TruckType type = 2 [json_name = "type"]; // filter by truck type
+  optional uint64 truck_type_id = 2 [json_name = "truck_type_id"]; // filter by truck type
 }
 
 message TruckListResponse {
@@ -33,7 +33,7 @@ message TruckListResponse {
 message CreateGuestTruckRequest {
   required uint64 owner_organization_id = 1 [json_name = "owner_organization_id"];
   required string plate_number = 2 [json_name = "plate_number"];
-  required TruckType type = 3 [json_name = "type"];
+  required uint64 truck_type_id = 3 [json_name = "truck_type_id"];
 }
 
 message TruckWeightRequest {

--- a/truck_type.proto
+++ b/truck_type.proto
@@ -1,0 +1,36 @@
+syntax = "proto2";
+package raccoonai;
+
+import "google/protobuf/timestamp.proto";
+
+option go_package = "./pb";
+
+message TruckType {
+  required uint64 id = 1;
+  required string name = 2 [json_name = "name"];
+  required google.protobuf.Timestamp created_at = 3 [json_name = "created_at"];
+  optional float volume = 4 [json_name = "volume"];
+  optional uint64 weight = 5 [json_name = "weight"];
+  required uint64 owner_organization_id = 6 [json_name = "owner_organization_id"];
+  required google.protobuf.Timestamp updated_at = 7 [json_name = "updated_at"];
+}
+
+// Simplified truck type for nested responses
+message TruckTypeRead {
+  required uint64 id = 1;
+  required string name = 2 [json_name = "name"];
+}
+
+message TruckTypeCreate {
+  required string name = 1 [json_name = "name"];
+  optional float volume = 2 [json_name = "volume"];
+  optional uint64 weight = 3 [json_name = "weight"];
+  optional uint64 owner_organization_id = 4 [json_name = "owner_organization_id"];
+}
+
+message TruckTypeUpdate {
+  required uint64 id = 1 [json_name = "id"];
+  optional string name = 2 [json_name = "name"];
+  optional float volume = 3 [json_name = "volume"];
+  optional uint64 weight = 4 [json_name = "weight"];
+}


### PR DESCRIPTION
- Add `visible_container_type_names` to `OrganizationSettings` messages.
- Add `container_group` field to `PickupLocation` messages.
- Introduce `ContainerTypeName` enum and replace `type_name` strings with enum usage.
- Deprecate unused fields and refine volume-related attributes in `ContainerType`.