### PR TITLE
feat(proto): replace design time range with design duration in route schema

### DIFF
--- a/organization_settings.proto
+++ b/organization_settings.proto
@@ -38,6 +38,7 @@ message OrganizationSettings {
   optional double map_center_lon = 10 [json_name = "map_center_lon"];
   optional bool ai_enabled = 11 [json_name = "ai_enabled"];
   optional TableColumnsConfig table_columns_config = 12 [json_name = "table_columns_config"];
+  optional double reward_coeff = 13 [json_name = "reward_coeff"];
 }
 
 message OrganizationSettingsCreate {

--- a/route.proto
+++ b/route.proto
@@ -43,6 +43,8 @@ message Route {
   optional RouteCategory route_category = 24 [json_name = "route_category"];
   repeated Job jobs = 25 [json_name = "jobs"];
   optional DriverOnShift driver_on_shift = 26 [json_name = "driver_on_shift"];
+  optional uint64 reward = 27 [json_name = "reward"];
+  optional double design_duration = 28 [json_name = "design_duration"];
 }
 
 message RouteCreate {


### PR DESCRIPTION
- Removed `design_start_at` and `design_end_at` fields.
- Added `design_duration` as a replacement.

Streamlines design time representation in the schema.