### PR TITLE
revert: remove depot_lat/depot_lon from RewardFormulas

### DIFF
--- a/admin_service.proto
+++ b/admin_service.proto
@@ -21,8 +21,6 @@ message RewardFormulas {
   optional int32 night_start_hour = 7 [json_name = "night_start_hour"];
   optional int32 night_end_hour = 8 [json_name = "night_end_hour"];
   optional string timezone = 9 [json_name = "timezone"];
-  optional double depot_lat = 10 [json_name = "depot_lat"];
-  optional double depot_lon = 11 [json_name = "depot_lon"];
 }
 
 message SetRewardFormulasRequest {


### PR DESCRIPTION
Reverts the depot_lat/depot_lon fields added in #179. Depot coordinates will instead be resolved via `OrganizationSettings.default_depot_id` FK in go-backend.