### PR TITLE
feat: list related organizations

### DIFF
--- a/organization_service.proto
+++ b/organization_service.proto
@@ -81,5 +81,6 @@ service OrganizationService {
   rpc ListDisposalSiteOperators(EmptyMessageRequest) returns (OrganizationList) {}
   rpc ListChildrenOrganization(EmptyMessageRequest) returns (OrganizationList) {}
   rpc GetOrganization(OrganizationRequest) returns (Organization) {}
+  rpc UpdateOrganization(OrganizationUpdate) returns (Organization) {}
   rpc MyOrganization(EmptyMessageRequest) returns (Organization) {}
 }

--- a/organization_service.proto
+++ b/organization_service.proto
@@ -54,7 +54,7 @@ message GrantParentAccessToChildOrgRequest {
   required string role = 2 [json_name = "role"];
 }
 
-message ListRelatedOrganizationsRequest {
+message ListCounterpartiesRequest {
   required uint64 organization_id = 1 [json_name = "organization_id"];
   required ContractStatus status = 2 [json_name = "status"];
 }
@@ -85,7 +85,7 @@ service OrganizationService {
   // general organization requests
   rpc ListDisposalSiteOperators(EmptyMessageRequest) returns (OrganizationList) {}
   rpc ListChildrenOrganization(EmptyMessageRequest) returns (OrganizationList) {}
-  rpc ListRelatedOrganizations(ListRelatedOrganizationsRequest) returns (OrganizationList) {}
+  rpc ListCounterparties(ListCounterpartiesRequest) returns (OrganizationList) {}
   rpc GetOrganization(OrganizationRequest) returns (Organization) {}
   rpc MyOrganization(EmptyMessageRequest) returns (Organization) {}
 }

--- a/organization_service.proto
+++ b/organization_service.proto
@@ -54,6 +54,11 @@ message GrantParentAccessToChildOrgRequest {
   required string role = 2 [json_name = "role"];
 }
 
+message ListRelatedOrganizationsRequest {
+  required uint64 organization_id = 1 [json_name = "organization_id"];
+  required ContractStatus status = 2 [json_name = "status"];
+}
+
 service OrganizationService {
   // requests releted to guest orgs and users, which will be used by waste disposals
   // to register in their system one-time clients
@@ -80,6 +85,7 @@ service OrganizationService {
   // general organization requests
   rpc ListDisposalSiteOperators(EmptyMessageRequest) returns (OrganizationList) {}
   rpc ListChildrenOrganization(EmptyMessageRequest) returns (OrganizationList) {}
+  rpc ListRelatedOrganizations(ListRelatedOrganizationsRequest) returns (OrganizationList) {}
   rpc GetOrganization(OrganizationRequest) returns (Organization) {}
   rpc MyOrganization(EmptyMessageRequest) returns (Organization) {}
 }


### PR DESCRIPTION
# Summary

Migrates `GET /list/related` from the Python backend to the `ListRelatedOrganizations` RPC on `OrganizationService`.

## Changes

### Proto

* Added `ListRelatedOrganizationsRequest`:

  * `organization_id`
  * `status` (`ContractStatus`)
* Added `ListRelatedOrganizations` RPC.
* `status` is required. Pass `CONTRACT_STATUS_UNDEFINED` to return organizations regardless of contract status.

### Repository

Implemented `ListRelatedOrganizations` using a single-query `UNION` subquery that resolves related organizations from both sides of a contract (`provider ↔ receiver`).

Key behavior:

* Filters by **time-based contract status**, not the contract status column.
* Hidden contracts are included when determining related organizations.
* Preloads `PrimaryContact`.

Contract status mapping:

* `ACTIVE` → `start_at <= now < end_at`
* `INACTIVE` → outside the active time window
* `UNDEFINED` → no status filter, returns all related organizations
* `HIDDEN` → returns `ErrInvalidEnumValue`

### Service / Handler

* Added service and handler wiring following existing patterns.
* Authorization is handled by the Permify interceptor.

## Additional Changes

### JSON Codec

Updated `internal/backend/interceptor/codec.go` to override Connect-Go's default JSON encoder and enable:

```go
EmitUnpopulated: true
```

This ensures optional proto fields are serialized as `null` instead of being omitted from responses.

The codec is applied globally through `withInterceptors` in `handlers.go`, affecting all JSON RPC responses.

## Response Compatibility

Validated against the existing REST endpoint:

* Same organization set returned.
* Same top-level fields returned.
* `PrimaryContact` is preloaded to preserve REST behavior.
* Optional fields are emitted as `null` to maintain response shape compatibility.
