### PR TITLE
feat: single-vehicle multi-trip VRP routing service (VrpRouting)

### DIFF
--- a/vrp_routing_service.proto
+++ b/vrp_routing_service.proto
@@ -1,0 +1,36 @@
+syntax = "proto2";
+
+package raccoonai;
+
+option go_package = "./pb";
+option java_outer_classname = "VrpRoutingServiceProto";
+option java_package = "com.raccoonai.vrprouting.grpc";
+
+// Basic single-vehicle VRP endpoint (TBO frontend).
+// Plans multi-trip visit sequences for one capacity-constrained truck:
+// trip 1 runs depot -> jobs -> disposal site, subsequent trips run
+// disposal site -> jobs -> disposal site. The depot is resolved from the
+// driver-on-shift's organization; it is not provided by the caller.
+service VrpRouting {
+  rpc SolveSingleVehicle(SolveSingleVehicleRequest) returns (SolveSingleVehicleResponse);
+}
+
+message SolveSingleVehicleRequest {
+  repeated int64 job_ids = 1 [json_name = "job_ids"]; // required, non-empty
+  required int64 disposal_site_id = 2 [json_name = "disposal_site_id"]; // end location of every trip
+  required int64 dos_id = 3 [json_name = "dos_id"]; // driver-on-shift -> truck capacity + depot
+}
+
+// One trip of the single vehicle; job_ids are in visit order.
+message VrpTrip {
+  repeated int64 job_ids = 1 [json_name = "job_ids"];
+}
+
+message SolveSingleVehicleResponse {
+  required string response_status = 1 [json_name = "response_status"]; // "ok" | "error"
+  // Trips in execution order: the depot-started trip first, the remaining
+  // trips all start and end at the disposal site.
+  repeated VrpTrip trips = 2 [json_name = "trips"];
+  repeated int64 unassigned_job_ids = 3 [json_name = "unassigned_job_ids"];
+  optional string error_message = 4 [json_name = "error_message"];
+}

--- a/vrp_routing_service.proto
+++ b/vrp_routing_service.proto
@@ -11,19 +11,19 @@ option java_package = "com.raccoonai.vrprouting.grpc";
 // trip 1 runs depot -> jobs -> disposal site, subsequent trips run
 // disposal site -> jobs -> disposal site. The depot is resolved from the
 // driver-on-shift's organization; it is not provided by the caller.
-service VrpRouting {
+service VrpRoutingService {
   rpc SolveSingleVehicle(SolveSingleVehicleRequest) returns (SolveSingleVehicleResponse);
 }
 
 message SolveSingleVehicleRequest {
-  repeated int64 job_ids = 1 [json_name = "job_ids"]; // required, non-empty
-  required int64 disposal_site_id = 2 [json_name = "disposal_site_id"]; // end location of every trip
-  required int64 dos_id = 3 [json_name = "dos_id"]; // driver-on-shift -> truck capacity + depot
+  repeated uint64 job_ids = 1 [json_name = "job_ids"]; // required, non-empty
+  required uint64 disposal_site_id = 2 [json_name = "disposal_site_id"]; // end location of every trip
+  required uint64 driver_on_shift_id = 3 [json_name = "driver_on_shift_id"]; // -> truck capacity + depot
 }
 
 // One trip of the single vehicle; job_ids are in visit order.
 message VrpTrip {
-  repeated int64 job_ids = 1 [json_name = "job_ids"];
+  repeated uint64 job_ids = 1 [json_name = "job_ids"];
 }
 
 message SolveSingleVehicleResponse {
@@ -31,6 +31,6 @@ message SolveSingleVehicleResponse {
   // Trips in execution order: the depot-started trip first, the remaining
   // trips all start and end at the disposal site.
   repeated VrpTrip trips = 2 [json_name = "trips"];
-  repeated int64 unassigned_job_ids = 3 [json_name = "unassigned_job_ids"];
+  repeated uint64 unassigned_job_ids = 3 [json_name = "unassigned_job_ids"];
   optional string error_message = 4 [json_name = "error_message"];
 }


### PR DESCRIPTION
## Summary

New `VrpRouting` service for the basic single-vehicle VRP endpoint (TBO frontend, quick win from the 2026-07-20 planning session):

- `SolveSingleVehicle(job_ids, disposal_site_id, dos_id)` → capacity-constrained multi-trip visit sequences (`trips: repeated VrpTrip`, each a `job_ids` list in visit order, depot-started trip first) + `unassigned_job_ids`.
- In-band error contract: `response_status` `"ok" | "error"` + `error_message`.
- Depot is resolved server-side from the driver-on-shift's org (not provided by the caller).

Python implementation lands in vrp_solver: Raccoon-AI/vrp_solver#113 (CI there is red until this merges and the submodule pointer is bumped). Go client for go-backend/TBO follows via `task proto grpc -t client -n VrpRouting`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)