### PR TITLE
feat: admin password set — UserService.SetUserPassword RPC

### DIFF
--- a/user.proto
+++ b/user.proto
@@ -55,6 +55,12 @@ message UserUpdateRole {
   required UserRole role = 2 [json_name = "role"];
 }
 
+message UserPasswordSet {
+  required uint64 id = 1 [json_name = "id"];
+  required uint64 owner_organization_id = 2 [json_name = "owner_organization_id"];
+  required string new_password = 3 [json_name = "new_password"];
+}
+
 message RegistrationTokenCreate {
   required string token = 1 [json_name = "token"];
   required uint64 owner_organization_id = 2 [json_name = "owner_organization_id"];

--- a/user_service.proto
+++ b/user_service.proto
@@ -16,4 +16,5 @@ service UserService {
   rpc UpdateUser(UserUpdate) returns (User) {}
   rpc ListUsers(UserListRequest) returns (UserList) {}
   rpc InviteUser(InviteUserRequest) returns (InviteUserResponse) {}
+  rpc SetUserPassword(UserPasswordSet) returns (User) {}
 }


### PR DESCRIPTION
**What**
Adds a new RPC that lets a caller with manage-user permission set another user's password directly, without knowing the current password. Until now the only password-change path was AuthService.ResetPassword, which requires the old password — so admins had no way to help a locked-out user other than recreating the account.

**Changes**
_Proto (proto_schema submodule, bumped to latest origin/main)_

New message UserPasswordSet { id, owner_organization_id, new_password } in user.proto
New RPC SetUserPassword(UserPasswordSet) returns (User) on UserService in user_service.proto
Note: the submodule bump also picks up unrelated upstream commits (container migration, VRP routing, PLG default_truck_id) that the Go code on main already depends on — the repo did not compile against the previously pinned commit