### PR TITLE
feat: human_review_reasons on AnalyzePhotosResponse

### DIFF
--- a/photo_analysis_service.proto
+++ b/photo_analysis_service.proto
@@ -52,14 +52,14 @@ message AnalyzePhotosResponse {
   // field names of this message (e.g. "is_service_complete"); renaming a
   // field renames its key.
   map<string, string> comments = 12 [json_name = "comments"];
+  // Set when response_status == "error"; names the offending image group
+  // and index for validation failures.
+  optional string error_message = 13 [json_name = "error_message"];
   // Reasons a human should re-check this event instead of trusting the
   // verdict as-is: cross-photo inconsistencies (e.g. before/after show
   // different sites), low confidence on some answer, ambiguous evidence.
   // Empty when nothing needs human review.
   repeated string human_review_reasons = 14 [json_name = "human_review_reasons"];
-  // Set when response_status == "error"; names the offending image group
-  // and index for validation failures.
-  optional string error_message = 13 [json_name = "error_message"];
 }
 
 // LLM-backed analysis of waste-collection service photos, served by

--- a/photo_analysis_service.proto
+++ b/photo_analysis_service.proto
@@ -62,7 +62,7 @@ message AnalyzePhotosResponse {
   optional string error_message = 13 [json_name = "error_message"];
 }
 
-// Gemini-backed analysis of waste-collection service photos, served by
+// LLM-backed analysis of waste-collection service photos, served by
 // vrp_solver. One request = one service event; one combined verdict out,
 // with errors answered in-band via response_status/error_message.
 service PhotoAnalysisService {

--- a/photo_analysis_service.proto
+++ b/photo_analysis_service.proto
@@ -52,6 +52,11 @@ message AnalyzePhotosResponse {
   // field names of this message (e.g. "is_service_complete"); renaming a
   // field renames its key.
   map<string, string> comments = 12 [json_name = "comments"];
+  // Reasons a human should re-check this event instead of trusting the
+  // verdict as-is: cross-photo inconsistencies (e.g. before/after show
+  // different sites), low confidence on some answer, ambiguous evidence.
+  // Empty when nothing needs human review.
+  repeated string human_review_reasons = 14 [json_name = "human_review_reasons"];
   // Set when response_status == "error"; names the offending image group
   // and index for validation failures.
   optional string error_message = 13 [json_name = "error_message"];


### PR DESCRIPTION
Adds `repeated string human_review_reasons = 14` to `AnalyzePhotosResponse`: reasons a human should re-check the event instead of trusting the verdict as-is — cross-photo inconsistencies (e.g. before/after photos show different sites), low confidence on some answer, ambiguous evidence. Empty when nothing needs review.

Follow-up to #217; consumed by Raccoon-AI/vrp_solver#137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)