### PR TITLE
feat: blacklist

### DIFF
--- a/blacklist.proto
+++ b/blacklist.proto
@@ -1,18 +1,12 @@
 syntax = "proto2";
 package raccoonai;
 
-import "general.proto";
 import "google/protobuf/timestamp.proto";
 import "pickup_location.proto";
 import "truck.proto";
 
 option go_package = "./pb";
 
-// A service provider's standing rule: trucks of the given truck type must
-// never be sent to the given pickup location. An absolute prohibition, not a
-// preference — the AI dispatcher must never plan a violating assignment.
-// truck_type_id references CustomTruckType; it and the pickup location must
-// belong to the same service provider.
 message Blacklist {
   required uint64 id = 1 [json_name = "id"];
   required uint64 service_provider_id = 2 [json_name = "service_provider_id"];
@@ -20,6 +14,7 @@ message Blacklist {
   required uint64 pickup_location_id = 4 [json_name = "pickup_location_id"];
   optional CustomTruckType truck_type = 5 [json_name = "truck_type"];
   optional PickupLocation pickup_location = 6 [json_name = "pickup_location"];
+  optional string reason = 7 [json_name = "reason"];
 
   required google.protobuf.Timestamp created_at = 101 [json_name = "created_at"];
 }
@@ -28,16 +23,15 @@ message BlacklistCreate {
   required uint64 service_provider_id = 1 [json_name = "service_provider_id"];
   required uint64 truck_type_id = 2 [json_name = "truck_type_id"];
   required uint64 pickup_location_id = 3 [json_name = "pickup_location_id"];
+  optional string reason = 4 [json_name = "reason"];
 }
 
 message BlacklistListRequest {
   repeated uint64 service_provider_ids = 1 [json_name = "service_provider_ids"];
   repeated uint64 pickup_location_ids = 2 [json_name = "pickup_location_ids"];
   repeated uint64 truck_type_ids = 3 [json_name = "truck_type_ids"]; // filter by custom truck type
-  optional ListFilter list_filter = 10 [json_name = "list_filter"];
 }
 
 message BlacklistList {
   repeated Blacklist blacklists = 1 [json_name = "blacklists"];
-  optional ListInfo list_info = 2 [json_name = "list_info"];
 }

--- a/blacklist.proto
+++ b/blacklist.proto
@@ -1,0 +1,43 @@
+syntax = "proto2";
+package raccoonai;
+
+import "general.proto";
+import "google/protobuf/timestamp.proto";
+import "pickup_location.proto";
+import "truck.proto";
+
+option go_package = "./pb";
+
+// A service provider's standing rule: trucks of the given truck type must
+// never be sent to the given pickup location. An absolute prohibition, not a
+// preference — the AI dispatcher must never plan a violating assignment.
+// truck_type_id references CustomTruckType; it and the pickup location must
+// belong to the same service provider.
+message Blacklist {
+  required uint64 id = 1 [json_name = "id"];
+  required uint64 service_provider_id = 2 [json_name = "service_provider_id"];
+  required uint64 truck_type_id = 3 [json_name = "truck_type_id"];
+  required uint64 pickup_location_id = 4 [json_name = "pickup_location_id"];
+  optional CustomTruckType truck_type = 5 [json_name = "truck_type"];
+  optional PickupLocation pickup_location = 6 [json_name = "pickup_location"];
+
+  required google.protobuf.Timestamp created_at = 101 [json_name = "created_at"];
+}
+
+message BlacklistCreate {
+  required uint64 service_provider_id = 1 [json_name = "service_provider_id"];
+  required uint64 truck_type_id = 2 [json_name = "truck_type_id"];
+  required uint64 pickup_location_id = 3 [json_name = "pickup_location_id"];
+}
+
+message BlacklistListRequest {
+  repeated uint64 service_provider_ids = 1 [json_name = "service_provider_ids"];
+  repeated uint64 pickup_location_ids = 2 [json_name = "pickup_location_ids"];
+  repeated uint64 truck_type_ids = 3 [json_name = "truck_type_ids"]; // filter by custom truck type
+  optional ListFilter list_filter = 10 [json_name = "list_filter"];
+}
+
+message BlacklistList {
+  repeated Blacklist blacklists = 1 [json_name = "blacklists"];
+  optional ListInfo list_info = 2 [json_name = "list_info"];
+}

--- a/blacklist_service.proto
+++ b/blacklist_service.proto
@@ -1,0 +1,17 @@
+syntax = "proto2";
+package raccoonai;
+
+import "blacklist.proto";
+import "general.proto";
+
+option go_package = "./pb";
+
+service BlacklistService {
+  // Creates a blacklist entry. Fails with an already-exists error if the
+  // (truck_type_id, pickup_location_id) pair is already blacklisted.
+  rpc CreateBlacklist(BlacklistCreate) returns (Blacklist) {}
+  // Lists blacklist entries, filterable by pickup location and/or truck type.
+  // Entries embed the full truck type and pickup location.
+  rpc ListBlacklists(BlacklistListRequest) returns (BlacklistList) {}
+  rpc DeleteBlacklist(IdRequest) returns (EmptyMessageResponse) {}
+}

--- a/blacklist_service.proto
+++ b/blacklist_service.proto
@@ -7,11 +7,7 @@ import "general.proto";
 option go_package = "./pb";
 
 service BlacklistService {
-  // Creates a blacklist entry. Fails with an already-exists error if the
-  // (truck_type_id, pickup_location_id) pair is already blacklisted.
   rpc CreateBlacklist(BlacklistCreate) returns (Blacklist) {}
-  // Lists blacklist entries, filterable by pickup location and/or truck type.
-  // Entries embed the full truck type and pickup location.
   rpc ListBlacklists(BlacklistListRequest) returns (BlacklistList) {}
   rpc DeleteBlacklist(IdRequest) returns (EmptyMessageResponse) {}
 }


### PR DESCRIPTION
## Why

Some pickup locations cannot be served by certain truck types — most often
because an authority prohibits it (e.g. a government restriction on moving
that type through the area), sometimes for physical access reasons. A human
dispatcher carries this knowledge in their head and silently respects it when
assigning a route to a truck. The AI dispatcher has no way to know, so it
plans assignments a human never would.

This adds the schema for the missing data: an explicit, per-provider list of
(truck type, pickup location) pairs that must never be assigned.

## What's in here

Two new files, schema only — no existing message or RPC is touched, so this is
backward compatible.

**`blacklist.proto`**

- `Blacklist` — `id`, `service_provider_id`, `truck_type_id`,
  `pickup_location_id`, `created_at`, plus optional embedded `truck_type`
  (`CustomTruckType`) and `pickup_location` for enriched list responses.
- `BlacklistCreate` — the three required IDs.
- `BlacklistListRequest` — repeated filters (`service_provider_ids`,
  `pickup_location_ids`, `truck_type_ids`) + standard `ListFilter`.
- `BlacklistList` — entries + `ListInfo`.

**`blacklist_service.proto`**

- `CreateBlacklist`, `ListBlacklists`, `DeleteBlacklist(IdRequest)`.

## Design decisions worth reviewing

- **`truck_type_id` references `CustomTruckType`, not the `TruckType` enum.**
  The enum is being deprecated on `Truck`, it's already org-scoped, and real
  restrictions are about concrete fleet types. Cost: banning "all MSW trucks"
  means one entry per matching custom truck type.
- **No `UpdateBlacklist`.** The entry has no mutable attribute — the pair is
  its identity, and `service_provider_id` is derived from its parents. Update
  would only mean "repoint at a different pair", which is a different rule.
  (`GroupMembership`/`ResourceAccessGrant` have Update because they carry
  mutable `role`/scope fields.) If a `reason` field is added later, Update
  arrives with it.
- **No `reason`, no `effective_from`/`effective_until`.** Deliberately out of
  scope: the motivating restrictions are open-ended, and temporal windows
  would complicate every enforcement point.
- **Absolute, not a preference.** The message comment states this for the
  benefit of the planner implementation: a blacklisted pair is never
  assignable, even if the location would otherwise go unserviced.
- **Field naming follows `Truck`** — `truck_type_id` / `truck_type`, matching
  `TruckCreate.truck_type_id` and `Truck.truck_type`, so the frontend sees the
  same `truckTypeId` / `truckType` shape it already uses. Note this does *not*
  copy the `json_name = "custom_truck_type_ids"` mismatch on
  `TruckListRequest.truck_type_ids`; here the field name and `json_name` agree.

## Consumers / follow-ups

- **go-backend:** `blacklists` table (unique index on
  `(truck_type_id, pickup_location_id)`, cascade delete with either parent),
  repository, service validating that both parents belong to the same service
  provider, handler, and Permify wiring mirroring truck-type management
  (`ActionManage` / `ActionView` on the truck resource + owner-org checks).
  `ApplyBulkAssignment` will re-validate incoming AI assignments and skip
  violating jobs.
- **AI dispatcher:** the planner is the real enforcement point. It reads its
  inputs from the shared Postgres DB, so it will consume the `blacklists`
  table directly — **merging this proto does not change planner behavior on
  its own**; that's a coordinated follow-up on the dispatcher side.
- **admin frontend:** blacklist management on the pickup-location page, plus a
  soft warning (not a block) when a human dispatcher makes a violating manual
  assignment.

## Verification

`make generate_proto` and `go build ./...` pass in go-backend against these
schemas.