### PR TITLE
refactor: serve the AI verification reads from GovDashService

### DIFF
--- a/ai_verification.proto
+++ b/ai_verification.proto
@@ -175,9 +175,7 @@ message AiVerificationByJobRequest {
   repeated uint64 district_organization_ids = 2 [json_name = "district_organization_ids"];
 }
 
-// Read-only access to the AI verification verdicts of jobs. Rows are produced
-// by batch checkers; nothing here writes them.
-service AiVerificationService {
-  rpc GetAiVerificationByJobId(AiVerificationByJobRequest) returns (AiVerification) {}
-  rpc ListAiVerifications(AiVerificationListRequest) returns (AiVerificationList) {}
-}
+// The RPCs that read these messages live on GovDashService
+// (gov_dash_service.proto): the verdicts are scoped by the caller's government
+// geo access, which is that service's own concern, so they are served there
+// rather than by a service of their own.

--- a/gov_dash_service.proto
+++ b/gov_dash_service.proto
@@ -2,6 +2,7 @@ syntax = "proto2";
 
 package raccoonai;
 
+import "ai_verification.proto";
 import "container.proto";
 import "contract.proto";
 import "enums.proto";
@@ -39,8 +40,8 @@ message GovJobListRequest {
   // be added later - see JobService.GovListJobs).
   optional string search = 11 [json_name = "search"];
   // Specific jobs by id, still narrowed to the caller's geo access. This is how a
-  // review queue built from AiVerificationService.ListAiVerifications fetches the
-  // flagged jobs themselves — the response carries each job's ai_verification.
+  // review queue built from ListAiVerifications fetches the flagged jobs
+  // themselves — the response carries each job's ai_verification.
   repeated uint64 job_ids = 12 [json_name = "job_ids"];
 }
 
@@ -381,4 +382,11 @@ service GovDashService {
   rpc GetGovAnalyticsLocationVisitsForAll(GovDashboardAnalyticsRequest) returns (GovAnalyticsLocationVisitsForAll) {}
   rpc GetGovAnalyticsAnomaliesForAll(GovDashboardAnalyticsRequest) returns (GovAnalyticsAnomaliesForAll) {}
   rpc GetGovDisposalVisits(GovDashboardAnalyticsRequest) returns (GovDisposalVisitList) {}
+
+  // AI verification verdicts of jobs (see ai_verification.proto). Read-only —
+  // the rows are produced by batch checkers — and scoped by the caller's geo
+  // access like every other endpoint here. GetAiVerificationByJobId reports a
+  // job outside that scope, or one no check has run for, as not found.
+  rpc GetAiVerificationByJobId(AiVerificationByJobRequest) returns (AiVerification) {}
+  rpc ListAiVerifications(AiVerificationListRequest) returns (AiVerificationList) {}
 }

--- a/job_service.proto
+++ b/job_service.proto
@@ -23,7 +23,7 @@ message JobListRequest {
   // the group-based flow carry no group and never match this filter).
   repeated uint64 pickup_location_group_ids = 13 [json_name = "pickup_location_group_ids"];
   // Specific jobs by id. Lets a caller that already has a set of job ids — e.g.
-  // from AiVerificationService.ListAiVerifications — fetch those jobs in full.
+  // from GovDashService.ListAiVerifications — fetch those jobs in full.
   repeated uint64 job_ids = 14 [json_name = "job_ids"];
 }
 


### PR DESCRIPTION
Follow-up to #226, from review on Raccoon-AI/go-backend#262.

## Why

The two RPCs landed in #226 as their own `AiVerificationService`, but they are government-dashboard endpoints in every respect that matters:

- gated on the `GOVERNMENT_AUDITOR` role, not permify (the dashboard bypasses permify by design — its access is data, via `gov_geo_access` rows, and the permify interceptor denies any procedure absent from its registry)
- scoped by the caller's geo access, expanded through district children, exactly like `Jobs`, `Trucks`, `PickupLocations`, and the rest

Serving them from a separate service meant the new handler had to reach into `GovDashHandler` for that scope resolution — a handler-to-handler dependency that exists nowhere else in the backend, coupling two services' authorization for no gain.

## What

`AiVerificationService` is removed; its two RPCs move onto `GovDashService`:

```proto
rpc GetAiVerificationByJobId(AiVerificationByJobRequest) returns (AiVerification) {}
rpc ListAiVerifications(AiVerificationListRequest) returns (AiVerificationList) {}
```

Everything else is untouched. `AiVerification`, `AiPhotoOverlayMetadata`, `AiVerificationList`, `AiVerificationScoreFilter`, and both request messages stay in `ai_verification.proto` — only the `service` block moves, plus a note there pointing at where the RPCs now live, and two doc comments that named the old service.

## Compatibility

**The wire path changes**: `/raccoonai.AiVerificationService/…` → `/raccoonai.GovDashService/…`. Request and response shapes are identical, so a client only re-points the call. Nothing consumes these endpoints yet — the go-backend side is still open in Raccoon-AI/go-backend#262, which is updated in lockstep and bumps the submodule to whatever this merges as.