### PR TITLE
feat(vrp-routing): optional start_location_id on SolveSingleVehicle

### DIFF
--- a/vrp_routing_service.proto
+++ b/vrp_routing_service.proto
@@ -8,9 +8,11 @@ option java_package = "com.raccoonai.vrprouting.grpc";
 
 // Basic single-vehicle VRP endpoint (TBO frontend).
 // Plans multi-trip visit sequences for one capacity-constrained truck:
-// trip 1 runs depot -> jobs -> disposal site, subsequent trips run
-// disposal site -> jobs -> disposal site. The depot is resolved from the
-// driver-on-shift's organization; it is not provided by the caller.
+// trip 1 runs start -> jobs -> disposal site, subsequent trips run
+// disposal site -> jobs -> disposal site. The start defaults to the truck's
+// depot, resolved from the driver-on-shift's organization, so day planning
+// needs no extra input; callers who know where the vehicle actually is pass
+// start_location_id instead.
 service VrpRoutingService {
   rpc SolveSingleVehicle(SolveSingleVehicleRequest) returns (SolveSingleVehicleResponse);
 }
@@ -19,6 +21,12 @@ message SolveSingleVehicleRequest {
   repeated uint64 job_ids = 1 [json_name = "job_ids"]; // required, non-empty
   required uint64 disposal_site_id = 2 [json_name = "disposal_site_id"]; // end location of every trip
   required uint64 driver_on_shift_id = 3 [json_name = "driver_on_shift_id"]; // -> truck capacity + depot
+  // Where the vehicle is when the plan starts; affects trip 1 only. Omitted
+  // means the truck's depot, i.e. day-planning behaviour. Mid-shift re-routing
+  // passes the disposal site, because that is where a truck that just announced
+  // itself full actually is - pricing trip 1 from a distant depot changes the
+  // order vroom picks for it.
+  optional uint64 start_location_id = 4 [json_name = "start_location_id"];
 }
 
 // One trip of the single vehicle; job_ids are in visit order.


### PR DESCRIPTION
## What

One optional, additive field on `SolveSingleVehicleRequest`:

```proto
// Where the vehicle is when the plan starts; affects trip 1 only. Omitted
// means the truck's depot, i.e. day-planning behaviour.
optional uint64 start_location_id = 4 [json_name = "start_location_id"];
```

Response unchanged. The service comment now says trip 1 runs `start -> jobs -> disposal site` rather than `depot -> ...`.

## Why

`SolveSingleVehicle` hard-wires trip 1 to begin at the truck's depot (`vrp_solver`, `app/trip_planner.py`: `Vehicle(start_id=depot_id, end_id=disposal_id)`). That is correct for day planning — the truck leaves the depot, fills up, ends at the disposal site.

The MSW truck-full re-routing work calls it **mid-shift**, at the moment a driver presses *«Поехали на Полигон»*. By then the truck is at or heading to the disposal site, not the depot. Pricing the first leg from the depot changes the order vroom picks for trip 1, so this is correctness rather than cosmetics. Prod has 44 active depots against 20 active disposal sites, so "depot far from disposal site" is the common case.

## Compatibility

Optional and additive; field number 4 was unused. An absent field must resolve exactly as today — truck `depot_id`, falling back to the org's oldest active `LOCATION_TYPE_DEPOT` — so the existing day-planning caller needs no change.

## Two deliberate choices

- **A location id, not a lat/lon pair.** Every other spatial input to this RPC is a DB id resolved and validated server-side. A raw coordinate would be the sole exception and would bypass the type/status checks.
- **Not type-constrained, unlike `disposal_site_id`.** This field means "where the vehicle is", and a caller may legitimately start from a depot, a disposal site, or elsewhere — only existence and `LOCATION_STATUS_ACTIVE` are validated. `disposal_site_id` *is* type-checked because it names where every trip **ends**: dumping at a pickup location would be a silent correctness bug, whereas starting from one is merely unusual.

## Considered and rejected

Per-trip `duration_seconds` on the response, so the consumer could check a plan against the shift end. Not needed — `go-backend` already prices routes with its own composite cost provider and derives every `plan_start_at`/`plan_end_at` from that. The solver's job here is ordering and grouping only.

## Consumers

- `vrp_solver` — implements the field, threaded through `resolve_trip_problem`; PR to follow.
- `go-backend` — passes the disposal site when re-routing; PR to follow.

Neither submodule pointer is bumped until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgqRuCdhNJgHtQpJqbQ8Hz