### PR TITLE
feat: containers_affected and confirmed_at on eco inspections

### DIFF
--- a/eco_inspect.proto
+++ b/eco_inspect.proto
@@ -108,8 +108,6 @@ message EcoInspect {
   optional string contact_name = 17 [json_name = "contact_name"];
   optional string contact_phone = 18 [json_name = "contact_phone"];
 
-  // Number of containers the provider's fix covered (repaired/replaced/cleaned…),
-  // reported with the after-media upload. Absent until the provider reports it.
   optional uint32 containers_affected = 19 [json_name = "containers_affected"];
 }
 
@@ -142,7 +140,6 @@ message EcoInspectUpdate {
   optional string comment = 8 [json_name = "comment"];
   // When present, replaces the linked contacts with these ids.
   repeated uint64 contact_ids = 9 [json_name = "contact_ids"];
-  // Officer correction of the provider-reported container count.
   optional uint32 containers_affected = 10 [json_name = "containers_affected"];
 }
 
@@ -151,8 +148,6 @@ message EcoInspectMediaUpload {
   optional uint64 id = 1 [json_name = "id"];
   required FileUploadType type = 2 [json_name = "type"];
   repeated File files = 3 [json_name = "files"];
-  // How many containers this fix covered. Accepted only with
-  // SITUATION_REPORT_AFTER uploads; must be >= 1 when present.
   optional uint32 containers_affected = 4 [json_name = "containers_affected"];
 }
 

--- a/eco_inspect.proto
+++ b/eco_inspect.proto
@@ -107,6 +107,10 @@ message EcoInspect {
 
   optional string contact_name = 17 [json_name = "contact_name"];
   optional string contact_phone = 18 [json_name = "contact_phone"];
+
+  // Number of containers the provider's fix covered (repaired/replaced/cleaned…),
+  // reported with the after-media upload. Absent until the provider reports it.
+  optional uint32 containers_affected = 19 [json_name = "containers_affected"];
 }
 
 message EcoInspectList {
@@ -138,6 +142,8 @@ message EcoInspectUpdate {
   optional string comment = 8 [json_name = "comment"];
   // When present, replaces the linked contacts with these ids.
   repeated uint64 contact_ids = 9 [json_name = "contact_ids"];
+  // Officer correction of the provider-reported container count.
+  optional uint32 containers_affected = 10 [json_name = "containers_affected"];
 }
 
 // EcoInspectMediaUpload appends media (images or videos) to a row.
@@ -145,6 +151,9 @@ message EcoInspectMediaUpload {
   optional uint64 id = 1 [json_name = "id"];
   required FileUploadType type = 2 [json_name = "type"];
   repeated File files = 3 [json_name = "files"];
+  // How many containers this fix covered. Accepted only with
+  // SITUATION_REPORT_AFTER uploads; must be >= 1 when present.
+  optional uint32 containers_affected = 4 [json_name = "containers_affected"];
 }
 
 message EcoInspectListRequest {

--- a/eco_inspect.proto
+++ b/eco_inspect.proto
@@ -109,6 +109,10 @@ message EcoInspect {
   optional string contact_phone = 18 [json_name = "contact_phone"];
 
   optional uint64 containers_affected = 19 [json_name = "containers_affected"];
+
+  // Stamped when the eco officer moves the inspection into REVIEWED; cleared if it
+  // leaves REVIEWED again. Non-null iff the inspection is currently REVIEWED.
+  optional google.protobuf.Timestamp confirmed_at = 20 [json_name = "confirmed_at"];
 }
 
 message EcoInspectList {

--- a/eco_inspect.proto
+++ b/eco_inspect.proto
@@ -108,7 +108,7 @@ message EcoInspect {
   optional string contact_name = 17 [json_name = "contact_name"];
   optional string contact_phone = 18 [json_name = "contact_phone"];
 
-  optional uint32 containers_affected = 19 [json_name = "containers_affected"];
+  optional uint64 containers_affected = 19 [json_name = "containers_affected"];
 }
 
 message EcoInspectList {
@@ -140,7 +140,7 @@ message EcoInspectUpdate {
   optional string comment = 8 [json_name = "comment"];
   // When present, replaces the linked contacts with these ids.
   repeated uint64 contact_ids = 9 [json_name = "contact_ids"];
-  optional uint32 containers_affected = 10 [json_name = "containers_affected"];
+  optional uint64 containers_affected = 10 [json_name = "containers_affected"];
 }
 
 // EcoInspectMediaUpload appends media (images or videos) to a row.
@@ -148,7 +148,7 @@ message EcoInspectMediaUpload {
   optional uint64 id = 1 [json_name = "id"];
   required FileUploadType type = 2 [json_name = "type"];
   repeated File files = 3 [json_name = "files"];
-  optional uint32 containers_affected = 4 [json_name = "containers_affected"];
+  optional uint64 containers_affected = 4 [json_name = "containers_affected"];
 }
 
 message EcoInspectListRequest {


### PR DESCRIPTION
## What

Two additions to the eco-inspection contract:

**Provider-reported container count**
- `EcoInspect.containers_affected = 19` — read model; absent until reported (never 0).
- `EcoInspectMediaUpload.containers_affected = 4` — the count rides along with the fix-proof ("after") media upload; must be ≥ 1 when present.
- `EcoInspectUpdate.containers_affected = 10` — direct set/correction; 0 clears back to "not reported".

**Status timestamp**
- `EcoInspect.confirmed_at = 20` — stamped when the eco officer moves the inspection into REVIEWED, cleared if it leaves REVIEWED (non-null iff currently REVIEWED). Together with `created_at` and `provider_report_uploaded_at` this enables duration tracking: Being Handled (created → uploaded) and Being Validated (uploaded → confirmed).

## Consumers

- Backend: Raccoon-AI/go-backend#290 (model, upload/update wiring, BeforeSave invariant, tests).
- Python backend: Raccoon-AI/backend#650 (alembic migration incl. backfill, ORM model).
- Frontend: monorepo #697 and a follow-up for duration columns.