### PR TITLE
refactor: remove dead AIDispatcherV4 and ResursDispatcher services

### DIFF
--- a/ai_dispatcher.proto
+++ b/ai_dispatcher.proto
@@ -112,15 +112,6 @@ message DayPlanResponse {
   map<string, int64> data_quality = 4 [json_name = "data_quality"];
 }
 
-service AIDispatcherV4 {
-  rpc OnDispatcherHeartbeat(AIDispatcherRequest) returns (BulkAssignmentResponse);
-  rpc OnCapacityPlan(AIDispatcherRequest) returns (CapacityPlanResponse);
-}
-
 service AIDispatcherV5 {
   rpc GetDayPlan(DayPlanRequest) returns (DayPlanResponse);
-}
-
-service ResursDispatcher {
-  rpc OnDispatcherHeartbeat(AIDispatcherRequest) returns (BulkAssignmentResponse);
 }

--- a/ai_dispatcher.proto
+++ b/ai_dispatcher.proto
@@ -11,15 +11,6 @@ message AIDispatcherRequest {
   required uint64 service_provider_id = 1 [json_name = "service_provider_id"];
 }
 
-message AssignmentResponse {
-  required RouteCreate route = 1 [json_name = "route"];
-  repeated JobUpdate jobs = 2 [json_name = "jobs"];
-}
-
-message BulkAssignmentResponse {
-  repeated AssignmentResponse responses = 1 [json_name = "responses"];
-}
-
 enum CapacityPlanResponseStatus {
   CAPACITY_PLAN_RESPONSE_STATUS_UNDEFINED = 0;
   CAPACITY_PLAN_RESPONSE_STATUS_OK = 1;


### PR DESCRIPTION
## Summary

v4 is end-of-life: the vrp_solver servicer was unregistered in vrp_solver #142, and the go-backend heartbeat client (CronJob binary, `ProcessAllProviders`, the discarded route-completion solve) was removed in go-backend #288. This removes the dead wire surface:

- `AIDispatcherV4` and `ResursDispatcher` service declarations (`ResursDispatcher` was declared but never served anywhere)
- `AssignmentResponse` / `BulkAssignmentResponse` — with the services gone no rpc in any .proto carries them, no code constructs them, and go-backend #288 deleted `ApplyBulkAssignment`

## Deliberately kept

- `AIDispatcherRequest`, `CapacityPlanResponse`, `DemandPrediction` — vrp_solver's capacity planner and demand predictor still construct them in-process.
- `RouteCreate`/`JobUpdate` stay embedded in dispatcher v5's `PlannedRoute` proposals (so the `job.proto`/`route.proto` imports remain exercised — verified with protoc).

## Cross-repo sequencing

vrp_solver PR 6 (Raccoon-AI/vrp_solver#158) pins its submodule to this branch; go-backend picks this up on its next routine proto-schema bump + pb regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)