### PR TITLE
feat: pickup location filters by job category, status and container type

### DIFF
--- a/container.proto
+++ b/container.proto
@@ -19,6 +19,8 @@ message ContainerType {
   required uint64 owner_organization_id = 3 [json_name = "owner_organization_id"];
   required float volume = 4 [json_name = "volume"];
   optional float weight_kg = 5 [json_name = "weight_kg"];
+  // Set only where the caller preloads it (GovDashService.GovListContainerTypes).
+  optional Organization owner_organization = 6 [json_name = "owner_organization"];
 
   optional google.protobuf.Timestamp created_at = 101 [json_name = "created_at"];
   optional google.protobuf.Timestamp updated_at = 102 [json_name = "updated_at"];

--- a/gov_dash_service.proto
+++ b/gov_dash_service.proto
@@ -58,6 +58,8 @@ message GovServiceProviderInfo {
   required string bin = 3 [json_name = "bin"];
   required uint64 number_of_trucks = 4 [json_name = "number_of_trucks"];
   optional uint64 parent_id = 5 [json_name = "parent_id"];
+  // The parent organization itself, for callers that render the hierarchy.
+  optional Organization parent = 6 [json_name = "parent"];
 }
 
 message GovServiceProviderInfoList {
@@ -86,6 +88,9 @@ message GovPickupLocationInfo {
   required double lon = 4 [json_name = "lon"];
   optional uint64 service_provider_id = 5 [json_name = "service_provider_id"];
   optional string service_provider_name = 6 [json_name = "service_provider_name"];
+  // The service provider organization itself; service_provider_name stays for
+  // callers already reading it.
+  optional Organization service_provider = 7 [json_name = "service_provider"];
 }
 
 message GovPickupLocationList {

--- a/gov_dash_service.proto
+++ b/gov_dash_service.proto
@@ -92,6 +92,13 @@ message GovPickupLocationList {
   repeated GovPickupLocationInfo pickup_locations = 1 [json_name = "pickup_locations"];
 }
 
+message GovPickupLocationListRequest {
+  required GovOrganizationRequest filter = 1 [json_name = "filter"];
+  // Only pickup locations hosting container groups of these container types.
+  repeated uint64 container_type_ids = 2 [json_name = "container_type_ids"];
+  repeated LocationStatus statuses = 3 [json_name = "statuses"];
+}
+
 message GovPickupLocationStats {
   required PickupLocation pickup_location = 1 [json_name = "pickup_location"];
   required Organization service_provider = 3 [json_name = "service_provider"];
@@ -376,7 +383,10 @@ service GovDashService {
   rpc GetGovGeoAccess(EmptyMessageRequest) returns (GovGeoAccessList) {}
   rpc ServiceProviders(GovOrganizationRequest) returns (GovServiceProviderInfoList) {}
   rpc ServiceReceivers(GovOrganizationRequest) returns (OrganizationList) {}
-  rpc PickupLocations(GovOrganizationRequest) returns (GovPickupLocationList) {}
+  rpc PickupLocations(GovPickupLocationListRequest) returns (GovPickupLocationList) {}
+  // Container types owned by the service providers in the caller's geo scope,
+  // each with its owner organization.
+  rpc ContainerTypes(GovOrganizationRequest) returns (ContainerTypeList) {}
   rpc DisposalSites(EmptyMessageRequest) returns (OrganizationList) {}
   rpc DisposalSiteLocations(EmptyMessageRequest) returns (LocationList) {}
   rpc Trucks(GovOrganizationRequest) returns (GovTruckList) {}

--- a/pickup_location_service.proto
+++ b/pickup_location_service.proto
@@ -19,6 +19,13 @@ message PickupLocationListRequest {
   repeated uint64 pickup_location_group_ids = 3 [json_name = "pickup_location_group_ids"];
   // Only pickup locations hosting container groups whose group binding carries this job type.
   optional JobType job_type = 4 [json_name = "job_type"];
+  // Only pickup locations hosting container groups of these container types.
+  repeated uint64 container_type_ids = 5 [json_name = "container_type_ids"];
+  // Only pickup locations hosting container groups whose contract prices a job
+  // type of one of these categories (the container group's service schedule is
+  // the fallback when the contract carries no tariff map).
+  repeated JobCategory job_categories = 6 [json_name = "job_categories"];
+  repeated LocationStatus statuses = 7 [json_name = "statuses"];
   optional ListFilter list_filter = 10 [json_name = "list_filter"];
 }
 


### PR DESCRIPTION
Filter fields for the pickup-location lists, plus a gov container-type endpoint.

## PickupLocationListRequest (`pickup_location_service.proto`)

- `container_type_ids = 5` — only locations hosting container groups of these types.
- `job_categories = 6` — only locations hosting container groups whose contract prices a job type of one of these categories. Plural to match `job_categories` in `job_service.proto` and `gov_dash_service.proto`.
- `statuses = 7` — location status, same shape as `statuses` in `container_service.proto` / `truck_service.proto`.

## GovDashService (`gov_dash_service.proto`)

- New `GovPickupLocationListRequest { filter, container_type_ids, statuses }`, and `rpc PickupLocations` now takes it instead of a bare `GovOrganizationRequest`. **Breaking for the gov client** — the old body moves under `filter`. Follows the `GovDashboardAnalyticsRequest` precedent of wrapping `GovOrganizationRequest`.
- New `rpc ContainerTypes(GovOrganizationRequest) returns (ContainerTypeList)` — container types owned by the service providers in the caller's geo scope. Named as a bare plural like `Trucks` / `Depots` / `PickupLocations`.

## ContainerType (`container.proto`)

- `owner_organization = 6` (optional `Organization`), set only where the caller preloads it — currently `GovDashService.ContainerTypes`.

Consumer side: Raccoon-AI/go-backend `feat/pl-filters`.
