### PR TITLE
feat: filter service receivers by job category

### DIFF
--- a/organization_service.proto
+++ b/organization_service.proto
@@ -39,6 +39,14 @@ message OrganizationRequest {
   required uint64 organization_id = 1 [json_name = "organization_id"];
 }
 
+message ServiceReceiverListRequest {
+  required uint64 organization_id = 1 [json_name = "organization_id"];
+  // Only receivers whose contract with this organization prices a job type of
+  // one of these categories (the contract's container group schedules are the
+  // fallback when it carries no tariff map).
+  repeated JobCategory job_categories = 2 [json_name = "job_categories"];
+}
+
 message ChildrenOrganizationListRequest {
   optional uint64 parent_organization_id = 1 [json_name = "parent_organization_id"]; // To be required
   optional ListFilter list_filter = 10 [json_name = "list_filter"];
@@ -71,7 +79,7 @@ service OrganizationService {
   rpc UpdateSetting(OrganizationSettingsUpdate) returns (OrganizationSettings) {}
 
   // can be used by service providers
-  rpc ListServiceReceivers(OrganizationRequest) returns (OrganizationList) {}
+  rpc ListServiceReceivers(ServiceReceiverListRequest) returns (OrganizationList) {}
   rpc CreateServiceReceiver(ServiceReceiverCreateRequest) returns (Organization) {}
 
   // can be used by service receivers


### PR DESCRIPTION
`ListServiceReceivers` gains a job-category filter.

New `ServiceReceiverListRequest { organization_id = 1, job_categories = 2 }`, and the rpc takes it instead of the shared `OrganizationRequest` — that message is also used by `GetOrganization`, so a receiver-only filter field has no business on it.

`organization_id` keeps field 1 and its json_name, so the request body is wire- and JSON-compatible for callers already sending it, and the generated `GetOrganizationId()` still satisfies the `organizationCheck` permission binding on the Go side.

Consumer side: Raccoon-AI/go-backend `feat/service-receiver-job-category`.