### PR TITLE
feat: TICKET-1224 job detach/notify RPCs and pickup location photos

### DIFF
--- a/job_service.proto
+++ b/job_service.proto
@@ -49,6 +49,12 @@ message DetachJobInstructionsRequest {
   repeated uint64 file_ids = 3 [json_name = "file_ids"];
 }
 
+message NotifyReceiverJobCompletedRequest {
+  required uint64 job_id = 1 [json_name = "job_id"];
+  required uint64 contact_id = 2 [json_name = "contact_id"];
+  required uint64 service_provider_id = 3 [json_name = "service_provider_id"];
+}
+
 service JobService {
   rpc CreateJob(JobCreate) returns (Job) {}
   rpc GetJobById(JobRequest) returns (Job) {}
@@ -59,4 +65,6 @@ service JobService {
   rpc ForceCompleteJob(JobRequest) returns (Job) {}
   rpc AttachJobInstructions(AttachJobInstructionsRequest) returns (Job) {}
   rpc DetachJobInstructions(DetachJobInstructionsRequest) returns (MessageResponse) {}
+  rpc DetachJobFromRoute(JobRequest) returns (Job) {}
+  rpc NotifyReceiverJobCompleted(NotifyReceiverJobCompletedRequest) returns (MessageResponse) {}
 }

--- a/job_service.proto
+++ b/job_service.proto
@@ -49,12 +49,6 @@ message DetachJobInstructionsRequest {
   repeated uint64 file_ids = 3 [json_name = "file_ids"];
 }
 
-message NotifyReceiverJobCompletedRequest {
-  required uint64 job_id = 1 [json_name = "job_id"];
-  required uint64 contact_id = 2 [json_name = "contact_id"];
-  required uint64 service_provider_id = 3 [json_name = "service_provider_id"];
-}
-
 service JobService {
   rpc CreateJob(JobCreate) returns (Job) {}
   rpc GetJobById(JobRequest) returns (Job) {}
@@ -66,5 +60,4 @@ service JobService {
   rpc AttachJobInstructions(AttachJobInstructionsRequest) returns (Job) {}
   rpc DetachJobInstructions(DetachJobInstructionsRequest) returns (MessageResponse) {}
   rpc DetachJobFromRoute(JobRequest) returns (Job) {}
-  rpc NotifyReceiverJobCompleted(NotifyReceiverJobCompletedRequest) returns (MessageResponse) {}
 }

--- a/notification_service.proto
+++ b/notification_service.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+package raccoonai;
+
+import "general.proto";
+
+option go_package = "./pb";
+
+message NotifyReceiverJobCompletedRequest {
+  required uint64 job_id = 1 [json_name = "job_id"];
+  required uint64 contact_id = 2 [json_name = "contact_id"];
+  required uint64 service_provider_id = 3 [json_name = "service_provider_id"];
+}
+
+service NotificationService {
+  rpc NotifyReceiverJobCompleted(NotifyReceiverJobCompletedRequest) returns (MessageResponse) {}
+}

--- a/pickup_location_service.proto
+++ b/pickup_location_service.proto
@@ -2,6 +2,7 @@ syntax = "proto2";
 package raccoonai;
 
 import "enums.proto";
+import "file_upload.proto";
 import "general.proto";
 import "pickup_location.proto";
 
@@ -44,6 +45,20 @@ message ReorderContainerGroupsRequest {
   repeated uint64 container_group_ids = 2 [json_name = "container_group_ids"];
 }
 
+message PickupLocationPhotosRequest {
+  required uint64 pickup_location_id = 1 [json_name = "pickup_location_id"];
+}
+
+message PickupLocationPhoto {
+  required FileUpload file_upload = 1 [json_name = "file_upload"];
+  optional string driver_first_name = 2 [json_name = "driver_first_name"];
+  optional string driver_last_name = 3 [json_name = "driver_last_name"];
+}
+
+message PickupLocationPhotoList {
+  repeated PickupLocationPhoto photos = 1 [json_name = "photos"];
+}
+
 message PickupLocationListToContractRequest {
   repeated uint64 pickup_location_ids = 1 [json_name = "pickup_location_ids"];
   required uint64 contract_id = 2 [json_name = "contract_id"];
@@ -71,6 +86,7 @@ service PickupLocationService {
   rpc UpdatePickupLocation(PickupLocationUpdate) returns (PickupLocation) {}
   rpc DeletePickupLocation(PickupLocationRequest) returns (MessageResponse) {}
   rpc ListPickupLocations(PickupLocationListRequest) returns (PickupLocationList) {}
+  rpc ListPickupLocationPhotos(PickupLocationPhotosRequest) returns (PickupLocationPhotoList) {}
   // @todeprecate
   rpc BindPickupLocationListToContract(PickupLocationListToContractRequest) returns (MessageResponse) {}
 


### PR DESCRIPTION
## What

New RPCs migrating the last legacy REST job endpoints to the gRPC contract:

- **JobService.DetachJobFromRoute(JobRequest) → Job** — unassigns a job from its route and resets it to CREATED so it can be re-planned. Replaces the legacy `POST /v1/platform/job/send` with `JOB_EVENT_DETACH_FROM_ROUTE` (the other events sent by the admin UI, CANCEL and FORCE_COMPLETE, already exist as CancelJob / ForceCompleteJob).
- **JobService.NotifyReceiverJobCompleted(NotifyReceiverJobCompletedRequest) → MessageResponse** — sends the "job completed" WhatsApp report to a contact. Replaces `POST /v1/platform/notification/receiver-job-notification`.
- **PickupLocationService.ListPickupLocationPhotos(PickupLocationPhotosRequest) → PickupLocationPhotoList** — latest driver-taken location photos, each FileUpload decorated with the driver's first/last name. Replaces `GET /v1/platform/job/photos/{pickup_location_id}`.

## Notes

- `NotifyReceiverJobCompletedRequest` carries `service_provider_id` for the standard permission check; the backend verifies it against the job.
- `PickupLocationPhotosRequest` carries only `pickup_location_id` — the backend resolves the authorized organizations from the entity.
