### PR TITLE
feat: GetShiftEngineHours for the admin ТТН page

### DIFF
--- a/analytics_service.proto
+++ b/analytics_service.proto
@@ -194,6 +194,33 @@ message TruckWorkSummaryResponse {
   repeated TruckWorkRow rows = 1 [json_name = "rows"];
 }
 
+// Моточасы per driver shift, for the admin ТТН (waybill) page. One row per shift, over the
+// same shift work window the engine-hours series uses, so both screens agree.
+message ShiftEngineHoursRequest {
+  required uint64 owner_organization_id = 1 [json_name = "owner_organization_id"];
+  optional DateFilter period = 2 [json_name = "period"];
+  optional uint64 driver_id = 3 [json_name = "driver_id"];
+  optional uint64 truck_id = 4 [json_name = "truck_id"];
+}
+
+// window_start_at / window_end_at bound the span the figure was computed over, which is the
+// shift's work window, not necessarily its full created-to-completed life.
+message ShiftEngineHoursRow {
+  optional uint64 shift_id = 1 [json_name = "shift_id"];
+  optional uint64 truck_id = 2 [json_name = "truck_id"];
+  optional uint64 driver_id = 3 [json_name = "driver_id"];
+  optional google.protobuf.Timestamp window_start_at = 4 [json_name = "window_start_at"];
+  optional google.protobuf.Timestamp window_end_at = 5 [json_name = "window_end_at"];
+  optional uint64 window_seconds = 6 [json_name = "window_seconds"];
+  // Unset when source is NONE -- absent telemetry is not zero engine time.
+  optional uint64 engine_seconds = 7 [json_name = "engine_seconds"];
+  optional EngineHoursSource source = 8 [json_name = "source"];
+}
+
+message ShiftEngineHoursResponse {
+  repeated ShiftEngineHoursRow rows = 1 [json_name = "rows"];
+}
+
 message RouteDetailsRequest {
   required uint64 owner_organization_id = 1 [json_name = "owner_organization_id"];
   optional DateFilter period = 2 [json_name = "period"];
@@ -253,6 +280,7 @@ service AnalyticsService {
   rpc GetFuelConsumptionSeries(FuelConsumptionSeriesRequest) returns (FuelConsumptionSeriesResponse) {}
   rpc GetEngineHoursSeries(EngineHoursSeriesRequest) returns (EngineHoursSeriesResponse) {}
   rpc GetTruckWorkSummary(TruckWorkSummaryRequest) returns (TruckWorkSummaryResponse) {}
+  rpc GetShiftEngineHours(ShiftEngineHoursRequest) returns (ShiftEngineHoursResponse) {}
   rpc GetRouteDetails(RouteDetailsRequest) returns (RouteDetailsResponse) {}
   rpc GetUnfulfilledJobs(UnfulfilledJobsRequest) returns (UnfulfilledJobsResponse) {}
 }

--- a/enums.proto
+++ b/enums.proto
@@ -443,3 +443,17 @@ enum WhatsappOrderStatus {
   WHATSAPP_ORDER_STATUS_CANCELLED = 6;
   WHATSAPP_ORDER_STATUS_EXPIRED = 7;
 }
+
+// Which telemetry a Моточасы (engine active hours) figure was derived from. Exposed so a
+// consumer can tell a measured figure from an absent one instead of reading 0 as "idle".
+enum EngineHoursSource {
+  ENGINE_HOURS_SOURCE_UNDEFINED = 0;
+  // Integral of the ignition/engine-operation sensor over the shift window. Fleet-wide on
+  // the Wialon Local orgs, and the preferred source.
+  ENGINE_HOURS_SOURCE_IGNITION = 1;
+  // Span of the cumulative CAN total_engine_hours counter. Only a handful of trucks carry a
+  // genuine hour meter.
+  ENGINE_HOURS_SOURCE_CAN_COUNTER = 2;
+  // The shift has a window but no usable engine telemetry in it.
+  ENGINE_HOURS_SOURCE_NONE = 3;
+}


### PR DESCRIPTION
Adds `AnalyticsService.GetShiftEngineHours` — Моточасы (engine active hours) per driver shift, which the coming **ТТН (waybill)** page in the admin app needs.

One row per shift, computed over the **same shift work window** the existing `GetEngineHoursSeries` uses, so the two screens can't disagree about моточасы for the same shift.

### Why `EngineHoursSource`

The figure has more than one possible provenance, and an absent figure must not be read as "the engine was off":

| source | coverage |
|---|---|
| `IGNITION` | integral of the engine-operation sensor — fleet-wide on the Wialon Local orgs (231 of 242 units), and the preferred source |
| `CAN_COUNTER` | span of the cumulative `total_engine_hours` counter — only ~5 trucks carry a genuine hour meter |
| `NONE` | the shift has a window but no usable telemetry in it |

`engine_seconds` is left **unset** when the source is `NONE`, rather than sent as 0.

`window_start_at` / `window_end_at` / `window_seconds` bound the span the figure was computed over, so a consumer can show моточасы against the window it actually covers.

Implemented in go-backend alongside this; the ignition column it reads is populated by Raccoon-AI/GPSDataService#45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkegyzsjN8pLPsMNANjPhu
