### PR TITLE
feat: TICKET-1226 gov driver-on-shift list, truck last shift and depot

### DIFF
--- a/driver_on_shift_service.proto
+++ b/driver_on_shift_service.proto
@@ -11,6 +11,9 @@ message DriverOnShiftListRequest {
   repeated uint64 owner_organization_ids = 1 [json_name = "owner_organization_ids"];
   required DateTimeFilter date_time_filter = 2 [json_name = "date_time_filter"];
   repeated DriverOnShiftStatus statuses = 3 [json_name = "statuses"];
+  // Keep only shifts that served at least one job at one of these pickup
+  // locations. Empty means no pickup-location narrowing.
+  repeated uint64 pickup_location_ids = 4 [json_name = "pickup_location_ids"];
   optional ListFilter list_filter = 10 [json_name = "list_filter"];
 }
 

--- a/gov_dash_service.proto
+++ b/gov_dash_service.proto
@@ -6,6 +6,7 @@ import "ai_verification.proto";
 import "container.proto";
 import "contract.proto";
 import "daily_summary.proto";
+import "driver_on_shift.proto";
 import "enums.proto";
 import "general.proto";
 import "google/protobuf/struct.proto";
@@ -116,6 +117,15 @@ message GovTruckInfo {
   optional double lat = 3 [json_name = "lat"];
   optional double lon = 4 [json_name = "lon"];
   optional uint32 angle = 5 [json_name = "angle"];
+  // The truck's current shift, or its most recent one if none is open now. Unset
+  // for a truck that has never been on shift. Only the shift's own fields are
+  // populated - its dates above all, which is what this is here for. Its driver,
+  // route and jobs are not, so read driver_id rather than driver.
+  optional DriverOnShift last_driver_on_shift = 6 [json_name = "last_driver_on_shift"];
+  // The truck's depot, from its depot_id. Unset means no depot is assigned -
+  // deliberately not inferred from the owner organization, since Depots counts
+  // a depot's trucks by depot_id alone and would then disagree.
+  optional Location depot = 7 [json_name = "depot"];
 }
 
 message GovTruckList {
@@ -384,6 +394,15 @@ message GovAiVerificationList {
   optional ListInfo list_info = 2 [json_name = "list_info"];
 }
 
+// Driver shifts of the caller's geo-scoped service providers, narrowed to shifts
+// that actually served one of the caller's service receivers.
+message GovDriverOnShiftListRequest {
+  required GovOrganizationRequest filter = 1 [json_name = "filter"];
+  required DateTimeFilter date_time_filter = 2 [json_name = "date_time_filter"];
+  repeated DriverOnShiftStatus statuses = 3 [json_name = "statuses"];
+  optional ListFilter list_filter = 10 [json_name = "list_filter"];
+}
+
 service GovDashService {
   rpc GetGovGeoAccess(EmptyMessageRequest) returns (GovGeoAccessList) {}
   rpc ServiceProviders(GovOrganizationRequest) returns (GovServiceProviderInfoList) {}
@@ -397,6 +416,7 @@ service GovDashService {
   rpc Trucks(GovOrganizationRequest) returns (GovTruckList) {}
   rpc Depots(GovOrganizationRequest) returns (GovDepotInfoList) {}
   rpc Jobs(GovJobListRequest) returns (JobList) {}
+  rpc DriverOnShifts(GovDriverOnShiftListRequest) returns (DriverOnShiftList) {}
   rpc ExportJobsReport(GovJobListRequest) returns (GovJobsReportResponse) {}
   rpc GetGovRawScaleRecordList(GovRawScaleRecordListRequest) returns (RawScaleRecordListResponse) {}
 


### PR DESCRIPTION
TICKET-1226: https://app.clickup.com/t/9018558220/TICKET-1226

Schema for two gov dashboard additions.

## `gov_dash_service.proto`

- `GovDriverOnShiftListRequest` + `rpc DriverOnShifts(...) returns (DriverOnShiftList)` — driver shifts of the caller's geo-scoped service providers, narrowed to shifts that served one of the caller's pickup locations.
- `GovTruckInfo.last_driver_on_shift = 6` — the truck's current shift, or its most recent one if none is open. Only the shift's own fields are populated (its dates above all); driver, route and jobs are not, so read `driver_id` rather than `driver`.
- `GovTruckInfo.depot = 7` — from `truck.depot_id`. Unset means no depot assigned, deliberately not inferred from the owner organization, since `Depots` counts a depot's trucks by `depot_id` alone and would then disagree.

## `driver_on_shift_service.proto`

- `DriverOnShiftListRequest.pickup_location_ids = 4` — keeps only shifts that served a job at one of these pickup locations. Empty means no narrowing.

## Why pickup locations and not service receivers

Both columns live on `job`, so either could scope the list. Measured on prod: scoping by the granted service receivers returns 2,173 jobs at 158 pickup locations **outside** the caller's geo access, because receivers are contractual parties that span districts while `gov_geo_access` is a geographic mandate. Coverage between the two is otherwise a wash (187 shifts, ~2%). The larger id list costs ~25 ms of query planning and nothing at execution.

Consumed by the matching `go-backend` PR — merge this first; that one bumps the submodule pointer to this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)